### PR TITLE
cleaned up deployment labels, ensured deploys always pull image

### DIFF
--- a/deploy/kubernetes/product_db_deploy.yaml
+++ b/deploy/kubernetes/product_db_deploy.yaml
@@ -3,6 +3,8 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: productdb 
+  labels:
+    name: productdb
   namespace: buttercup-store
 spec:
   replicas: 1
@@ -10,12 +12,14 @@ spec:
     metadata:
       labels:
         app: buttercup-store
+        name: productdb
         role: mysql
         tier: db 
     spec:
       containers:
         - name: productdb
           image: derkkila/product_db
+          imagePullPolicy: Always
           ports:
             - name: mysql 
               containerPort: 3306

--- a/deploy/kubernetes/product_microservice_deploy.yaml
+++ b/deploy/kubernetes/product_microservice_deploy.yaml
@@ -10,12 +10,14 @@ spec:
     metadata:
       labels:
         app: buttercup-store
+        name: productservice
         role: productservice
         tier: middleware 
     spec:
       containers:
         - name: productservice
           image: derkkila/product_microservice
+          imagePullPolicy: Always
           ports:
             - name: productservice
               containerPort: 6767


### PR DESCRIPTION
Kube services were pointing at labels that the pods didn't have. Updated and confirmed endpoints now configured. updated deploys to always pull images to ensure latest images is always in use. 